### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vanessa-cooper @carl-rattmann

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vanessa-cooper @carl-rattmann
+* @vanessa-cooper


### PR DESCRIPTION
# Description

We will add a `codeowners` file which will help GitHub assign reviewers automatically.